### PR TITLE
Guard nightly rolling tag against partial-platform manual builds

### DIFF
--- a/.github/workflows/docker-publish-nightly.yml
+++ b/.github/workflows/docker-publish-nightly.yml
@@ -32,21 +32,35 @@ jobs:
           *)       TAG="${REF#v}-nightly";     HUMHUB_BRANCH="$REF" ;;
         esac
 
-        # Manual dispatch may pick the platforms explicitly. The cron / workflow_call
-        # path supplies no such input, so fall back to the ref gate: only develop
-        # (experimental-nightly) is multiarch; every other ref stays amd64-only.
+        # Canonical platform set per ref (what the automated nightly builds):
+        # only develop (experimental-nightly) is multiarch; every other ref is amd64.
+        case "$REF" in
+          develop) CANONICAL="linux/amd64,linux/arm64" ;;
+          *)       CANONICAL="linux/amd64" ;;
+        esac
+
+        # Manual dispatch may narrow the platforms; the cron / workflow_call path
+        # supplies no input and uses the canonical set.
         PLATFORMS="${{ inputs.platforms }}"
         if [ -z "$PLATFORMS" ]; then
-          case "$REF" in
-            develop) PLATFORMS="linux/amd64,linux/arm64" ;;
-            *)       PLATFORMS="linux/amd64" ;;
-          esac
+          PLATFORMS="$CANONICAL"
+        fi
+
+        # The rolling channel tag (e.g. experimental-nightly) only moves for a full
+        # canonical build. A manual run that narrows the platform set (amd64-only or
+        # arm64-only) is a test: it publishes the immutable tag only and must not
+        # clobber the shared tag with a partial image.
+        if [ "$PLATFORMS" = "$CANONICAL" ]; then
+          PUSH_ROLLING="true"
+        else
+          PUSH_ROLLING="false"
         fi
 
         echo "ref=$REF"                     >> $GITHUB_OUTPUT
         echo "tag=$TAG"                     >> $GITHUB_OUTPUT
         echo "humhub_branch=$HUMHUB_BRANCH" >> $GITHUB_OUTPUT
         echo "platforms=$PLATFORMS"         >> $GITHUB_OUTPUT
+        echo "push_rolling=$PUSH_ROLLING"   >> $GITHUB_OUTPUT
 
     - uses: actions/checkout@v4
       with:
@@ -78,8 +92,9 @@ jobs:
         file: ./image/Dockerfile
         platforms: ${{ steps.resolve.outputs.platforms }}
         push: true
+        provenance: false
         build-args: |
           HUMHUB_GIT_BRANCH=${{ steps.resolve.outputs.humhub_branch }}
         tags: |
-          humhub/humhub:${{ steps.resolve.outputs.tag }}
           humhub/humhub:${{ steps.immutable.outputs.value }}
+          ${{ steps.resolve.outputs.push_rolling == 'true' && format('humhub/humhub:{0}', steps.resolve.outputs.tag) || '' }}

--- a/docs/multiarch-arm64.md
+++ b/docs/multiarch-arm64.md
@@ -12,6 +12,9 @@ Working notes for adding `linux/arm64` support to the HumHub Docker image.
   - `.github/workflows/docker-publish-release.yml`
 - Branch-name gating is **not** rotation-proof: a gate keyed on `develop`/`main` is evaluated at runtime by branch name, but code rotates while the names stay put. Use it only for nightly; use **version gating** for releases.
 - **Automated (cron) nightly runs from `main`.** The cron dispatcher fires from the default branch and calls the inner workflow via a local `uses: ./...` ref, so GitHub resolves the **workflow steps from `main`**, regardless of the matrix `ref`. Only the **build context** (`Dockerfile`, `image/*`) is checked out from the `ref` input. Therefore develop-only changes to the workflow *steps* do **not** affect the automated nightly until rotation carries them to main. The arm64 *image* for v1.18 stays off via the gate either way.
+- **Rolling channel tags must not be moved by partial builds.** The rolling tag (`experimental-nightly`) and the immutable `…-<ts>-<sha>` tag are pushed on every run. A manual run that narrows the platform set (amd64-only or arm64-only) would otherwise overwrite the shared `experimental-nightly` with a single-arch image — breaking `docker pull` for the other arch. Guard: only push the rolling tag when the resolved platform set equals the ref's **canonical** set (develop → both); narrowed manual runs publish the immutable tag only.
+- **Pre-rotation, multiarch `experimental-nightly` is not durable.** Cron (main's pre-buildx, amd64-only workflow) re-points `experimental-nightly` to amd64 every night. A manual full build makes it multiarch only until the next cron run. Accepted for now; becomes durable at rotation when the buildx workflow reaches main.
+- `docker/build-push-action@v6` attaches a provenance attestation by default — it shows on Docker Hub as an ~81 kB `unknown/unknown` image. Set `provenance: false` to suppress it.
 
 ## Branch rotation (at v1.19 release)
 
@@ -27,8 +30,8 @@ Constraints:
 
 ## Steps from now until final rotation
 
-1. **Branch** — `enh/docker-multiarch-arm64` off `develop` (done). PR targets `develop` only; never merge to current `main`.
-2. **Step 1 — nightly, develop-only**
+1. **Branch** — `enh/docker-multiarch-arm64` off `develop`. PR targets `develop` only; never merge to current `main`. (done — merged via PR #12)
+2. **Step 1 — nightly, develop-only** (done — merged via PR #12)
    - Convert `docker-publish-nightly.yml` to buildx (`setup-qemu-action`, `setup-buildx-action`, `build-push-action@v6`).
    - Add `--platform=$BUILDPLATFORM` to the builder stage in `image/Dockerfile`.
    - Add a `workflow_dispatch` input `platforms` (choice: `linux/amd64`, `linux/amd64,linux/arm64`, `linux/arm64`; default both) so a manual run can pick architecture explicitly — including an isolated **arm64-only** smoke test.
@@ -39,7 +42,10 @@ Constraints:
    # or select a specific platform set in the Actions UI via the `platforms` input
    ```
    Then pull `humhub/humhub:experimental-nightly` on ARM hardware; confirm build + boot. Current `main` is untouched; automated multiarch nightly switches on for free at rotation (develop → new main).
-4. **Merge Step 1** into `develop`.
+4. **Step 1a — rolling-tag guard + provenance** (follow-up fix to Step 1)
+   - In `resolve`, compute the ref's `CANONICAL` platform set and a `push_rolling` flag (`true` only when the resolved platforms equal `CANONICAL`).
+   - In the build step, always push the immutable `…-<ts>-<sha>` tag; push the rolling `experimental-nightly` tag only when `push_rolling == 'true'`. Narrowed manual runs (amd64-only / arm64-only) therefore publish the immutable tag only and never move `experimental-nightly`.
+   - Add `provenance: false` to drop the ~81 kB attestation image from Docker Hub.
 5. **Step 2 — releases**
    - Convert `docker-publish-release.yml` to buildx the same way.
    - Gate arm64 on **HumHub version `>= 1.19`** (from the computed `MINOR`), **not** branch name. v1.18.x stays amd64-only; 1.19+ always multiarch.


### PR DESCRIPTION
Follow-up fix to the nightly multiarch work (#12). Refs [#8](https://github.com/humhub/docker/issues/8).

A manual `arm64`-only dispatch on `develop` revealed that the workflow moved the rolling `experimental-nightly` tag to a single-arch image, breaking `docker pull` for the other architecture. It also left an ~81 kB `unknown/unknown` provenance image on Docker Hub.

### Changes

- **Rolling-tag guard** — `resolve` now computes the ref's canonical platform set and a `push_rolling` flag. The rolling channel tag (`experimental-nightly`) is pushed **only when the resolved platforms equal the canonical set** (develop → both). The immutable `…-<ts>-<sha>` tag is always pushed.
- **`provenance: false`** — drops the ~81 kB attestation image from the Docker Hub listing.

### Resulting behavior (develop)

| Manual trigger | Tags pushed | `experimental-nightly` |
|---|---|---|
| amd64-only | immutable only | not moved |
| arm64-only | immutable only | not moved |
| both | immutable + `experimental-nightly` (multiarch) | shifts |

Automated cron is unaffected — `main` still runs its pre-buildx workflow and produces the nightly amd64 `experimental-nightly` from develop as before. After the v1.19 rotation, the cron/`workflow_call` path resolves `push_rolling=true` for the canonical develop build, so multiarch automation turns on consistently.
